### PR TITLE
Verify nvme-rdma module is loaded

### DIFF
--- a/config-linux/nvme-ib-setup-host-side-task.adoc
+++ b/config-linux/nvme-ib-setup-host-side-task.adoc
@@ -196,3 +196,16 @@ As shown in the example below, the IP address for `ib1` is `11.11.11.255`.
 # cat /etc/modules-load.d/nvme-rdma.conf
   nvme-rdma
 ----
+To verify the `nvme-rdma` kernel module is loaded, run this command:
++
+----
+
+# lsmod | grep nvme
+nvme_rdma              36864  0
+nvme_fabrics           24576  1 nvme_rdma
+nvme_core             114688  5 nvme_rdma,nvme_fabrics
+rdma_cm               114688  7 rpcrdma,ib_srpt,ib_srp,nvme_rdma,ib_iser,ib_isert,rdma_ucm
+ib_core               393216  15 rdma_cm,ib_ipoib,rpcrdma,ib_srpt,ib_srp,nvme_rdma,iw_cm,ib_iser,ib_umad,ib_isert,rdma_ucm,ib_uverbs,mlx5_ib,qedr,ib_cm
+t10_pi                 16384  2 sd_mod,nvme_core
+----
++


### PR DESCRIPTION
Step 7 mentions adding a file that'll load the nvme-rdma kernel module after a host reboot, but does not mention how to validate that it loaded properly - jduong@netapp.com