### PR TITLE
Updating multipath.conf location iSER

### DIFF
--- a/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
+++ b/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
@@ -15,4 +15,4 @@ The multipath.conf file overrides the built-in configuration table for multipath
 
 NOTE: For SANtricity operating system 8.30 and newer, NetApp recommends using the default settings as provided.
 
-The multipath.conf files are available in /etc/multipath.conf
+No changes to /etc/multipath.conf are required.

--- a/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
+++ b/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
@@ -11,16 +11,4 @@ summary: Use the multipath.conf file, which is the configuration file for the mu
 [.lead]
 The multipath.conf file is the configuration file for the multipath daemon, multipathd.
 
-The multipath.conf file overrides the built-in configuration table for multipathd. Any line in the file with a first non-white-space character of # is considered a comment line.
-
-NOTE: For SANtricity operating system 8.30 and newer, NetApp recommends using the default settings as provided.
-
-The multipath.conf files are available in the following locations:
-
-* For SLES:
-+
-`/usr/share/doc/packages/multipath-tools/multipath.conf.synthetic`
-
-* For RHEL:
-+
-`/usr/share/doc/device-mapper-multipath-0.4.9/multipath.conf`
+The multipath.conf file overrides the built-in configuration table for multipathd. /etc/multipath.conf should be empty.

--- a/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
+++ b/config-linux/iser-ib-setup-multipath-conf-file-concept.adoc
@@ -11,4 +11,8 @@ summary: Use the multipath.conf file, which is the configuration file for the mu
 [.lead]
 The multipath.conf file is the configuration file for the multipath daemon, multipathd.
 
-The multipath.conf file overrides the built-in configuration table for multipathd. /etc/multipath.conf should be empty.
+The multipath.conf file overrides the built-in configuration table for multipathd.
+
+NOTE: For SANtricity operating system 8.30 and newer, NetApp recommends using the default settings as provided.
+
+The multipath.conf files are available in /etc/multipath.conf


### PR DESCRIPTION
Simplifying wording to by stating /etc/multipath.conf should be empty for SCSI and updating locations to call out /etc/multipath.conf as opposed to what was previously listed - jduong@netapp.com