### PR TITLE
Update controllers-simplex-supertask-task.adoc

### DIFF
--- a/maintenance-e2800/controllers-simplex-supertask-task.adoc
+++ b/maintenance-e2800/controllers-simplex-supertask-task.adoc
@@ -14,7 +14,6 @@ You can replace a failed controller canister in a simplex (single-controller) co
 
 * E2812 controller shelf
 * E2824 controller shelf
-* EF280 flash array
 
 .About this task
 


### PR DESCRIPTION
Removed EF280 from the supported shelves section. EF280 is not supported in Simplex configuration.